### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 [![Run Code Checks](https://github.com/RESOStandards/reso-upi-v2/actions/workflows/codecheck.yml/badge.svg)](https://github.com/RESOStandards/reso-upi-v2/actions/workflows/codecheck.yml) &nbsp; [![CodeQL](https://github.com/RESOStandards/reso-upi-v2/actions/workflows/codeql.yml/badge.svg)](https://github.com/RESOStandards/reso-upi-v2/actions/workflows/codeql.yml)
 
 
-# Universal Property Identifier (UPI) Version 2
+# Universal Property Identifier (UPI) Version 2.0
 
-The UPI is a way to take a set of well-known Property identifiers and encode them in a way such that if two parties both have the same data, they can create the identifiers and match on them. This is useful for deduplicating data.
+The UPI is a way to take a set of well-known property identifiers and encode them in a way for two parties with the same data to create matchable identifiers. This is useful for deduplicating data.
 
-UPIs can also easily be searched on by parts and be used with URIs as part of a browser location or API URL, since they are friendly with existing URI standards.
+UPIs can also easily be searched on by parts and be used with Uniform Resource Identifiers (URIs) as part of a browser location or API URL, since they are friendly with existing URI standards.
 
 ## Uniform Resource Names (URNs)
 
-[**Uniform Resource Names**](https://en.wikipedia.org/wiki/Uniform_Resource_Name) are a type of [**Uniform Resource Identifier (URI)**](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) that allow globally unique identifiers to be created using a namespace. 
+[**URNs**](https://en.wikipedia.org/wiki/Uniform_Resource_Name) are a type of [**URI**](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) that allow globally unique identifiers to be created using a namespace. 
 
-They are a general Internet standard from IANA and IETF, which are in many enterprise-scale applications such as AWS and LinkedIn.
+They are a general Internet standard from the Internet Assigned Numbers Authority (IANA) and the Internet Engineering Task Force (IETF), which are in many enterprise-scale applications such as Amazon Web Services (AWS) and LinkedIn.
 
-RESO has a reserved URN which includes v1 UPI identifiers. [**See section 3.4.2**](https://www.iana.org/assignments/urn-formal/reso).
+RESO has a reserved URN that includes UPI 1.0 identifiers. [**See section 3.4.2**](https://www.iana.org/assignments/urn-formal/reso).
 
 ## URN Encoding Scheme
-In order to avoid collisions with special characters and preserve data passed in the URN, UPIv2 takes the following approach:
+In order to avoid collisions with special characters and preserve data passed in the URN, UPI 2.0 takes the following approach:
 
 > _The delimiters are the components of the UPI!_
 
-What does this mean, in practice? 
+What does this mean, in practice?
 
-The UPI includes Country as part of constituent data. This means it has a component called `:country:` which is also a delimiter. This avoids the need for special delimiters.
+The UPI includes **country** as part of constituent data. This means it has a component called `:country:` that is also a delimiter, avoiding the need for special delimiters.
 
 ## Examples
 
@@ -37,11 +37,11 @@ Let's look at the individual parts:
 * `2.0` is the version of the UPI
 * `country` is `US` in this case (ISO Country Code)
 * `stateorprovince` is `CA` for California (USPS)
-* `county` is a FIPS county code
-* `subcounty` is an optional FIPS sub-county code, however it's empty here (`:subcounty::`)
+* `county` is a Federal Information Processing Standards (FIPS) county code
+* `subcounty` is an optional FIPS subcounty code that is empty in this case (`:subcounty::`)
 * `propertytype` is an optional Data Dictionary type, in this case Residential
 * `subpropertytype` is empty in this case
-* `parcelnumber` shows a number of weird characters, including brackets, colons, and spaces, but since the components are the delimiters, the original values are preserved
+* `parcelnumber` shows a number of weird characters, including brackets, colons and spaces, but since the components are the delimiters, the original values are preserved
 * `subparcelnumber` is empty in this case (no values after the last `:`)
 
 This UPI can be decoded into a RESO Common Format payload using the `decode` function.
@@ -61,15 +61,15 @@ This UPI can be decoded into a RESO Common Format payload using the `decode` fun
   Country: 'US',
   StateOrProvince: 'CA',
   County: '06037',
-  SubCounty: null,
+  Subcounty: null,
   PropertyType: 'Residential',
-  SubPropertyType: null,
+  SubpropertyType: null,
   ParcelNumber: ' [abc] 1-2 ::   3:456 ',
-  SubParcelNumber: null
+  SubparcelNumber: null
 }
 ```
 
-Note that any item without data in it is null, and that all special characters are preserved in the ParcelNumber. This would be true if special characters were used in any of the values, not just ParcelNumber.
+Note that any item without data in it is null and that all special characters are preserved in the ParcelNumber. This would be true if special characters were used in any of the values, not just ParcelNumber.
 
 
 ### Encode a UPI from a RESO Common Format Payload
@@ -87,11 +87,11 @@ We can do so using the `encode` function:
   Country: 'US',
   StateOrProvince: 'CA',
   County: '06037',
-  SubCounty: null,
+  Subcounty: null,
   PropertyType: 'Residential',
-  SubPropertyType: null,
+  SubpropertyType: null,
   ParcelNumber: ' [abc] 1-2 ::   3:456 ',
-  SubParcelNumber: null
+  SubparcelNumber: null
 };
 
 > const upi = encode({upiData});
@@ -102,17 +102,17 @@ We can do so using the `encode` function:
 
 ### Other Benefits of URNs
 * Since `version` is included, different formulas could be used for different versions and accommodate future changes or improvements without making backwards-breaking changes.
-* v1 URNs are also supported, they're just not encoded using the component scheme shown here. They could either be prefixed with `1.0` in place of `2.0`, above, or we can assume that if the data in the DD field does not start with `urn:reso:upi`, that it's in the v1 format.
-* Since the URN-based UPI essentially encodes key/value pairs, it's extensible and could even support local components.
+* v1 URNs are also supported, but they are not encoded using the component scheme shown here. They could either be prefixed with `1.0` in place of `2.0`, or we can assume that if the data in the Data Dictionary field does not start with `urn:reso:upi`, that it's in the v1 format.
+* Since the URN-based UPI essentially encodes key/value pairs, it is extensible and could even support local components.
 * The URN-based UPI is self-documenting and human friendly, since each component is explicitly named. We know that the first element is `:country:` and what its value is, and that the second value is `:stateorprovince:`, etc.
 
 # UPI Hashes
 
-In the U.S., Parcel Numbers are a matter of public record. However, in other countries / scenarios, there may be some data that cannot be conveyed due to intellectual property concerns or for other reasons.
+In the U.S., parcel numbers are a matter of public record. However, in other countries/scenarios, there may be some data that cannot be conveyed due to intellectual property concerns or for other reasons.
 
-The matching and deduplication aspects of the UPI still work even when hashed since if the same components and data were used between two records, their hashes would be the same.
+The matching and deduplication aspects of the UPI still work even when hashed. If the same components and data were used between two records, their hashes would be the same.
 
-As for choice of hashes, since we're dealing with particularly sensitive data that others wouldn't want shared, one-way hashing (i.e. cryptographic hashing) is a natural choice since it sufficiently obscures the source data. They're also [**NIST**](https://csrc.nist.gov/projects/hash-functions) and global standards used in large-scale production environments like GitHub, Blockchain and Ethereum, and have support out of the box in programming languages and frameworks. 
+As for choice of hashes, since we are dealing with particularly sensitive data that others would not want shared, one-way hashing (i.e., cryptographic hashing) is a natural choice, as it sufficiently obscures the source data. They are also [**NIST**](https://csrc.nist.gov/projects/hash-functions) and global standards used in large-scale production environments like GitHub, Blockchain and Ethereum, and they have support out of the box in programming languages and frameworks. 
 
 One-way hashes also offer collision-resistance, which is important for the universality of the UPI.
 
@@ -138,7 +138,7 @@ To create a UPI hash from this value, use the `hash` function:
 'urn:reso:upi:2.0:sha3-256-hash:427c883322af677b76d72d43d9a00c3bedd6a1ede20e43c614f710abf85549a9'
 ```
 
-Note that the component representing the UPI hash also includes the method that was used for hashing. This seems practical, and offers the ability to support different kinds of hashing, should the need arise. 
+Note that the component representing the UPI hash also includes the method that was used for hashing. This seems practical and offers the ability to support different kinds of hashing, should the need arise. 
 
 
 # Installation
@@ -151,7 +151,7 @@ npm i RESOStandards/reso-upi-v2
 ```
 
 ## Installing and Running Locally
-If you would like to run the project locally, install [**Node**](https://nodejs.org/en/download) and [**git**](https://github.com/git-guides/install-git) if you don't have them already.
+If you would like to run the project locally and do not have them already, install [**Node**](https://nodejs.org/en/download) and [**git**](https://github.com/git-guides/install-git).
 
 ```
 > mkdir [PROJECT_LOCATION]


### PR DESCRIPTION
Feel free to reject or accept my changes, all based on my professional obsession with clean English. I think all of the changes are worthy and clarifying, but I'm biased.

Here are my rationale list notes for your consideration:

1) In general, I try to reduce Overcapitalization. It's a real estate-wide problem, heh.

2) I think it's important to spell out organizational acronyms like IANA, IETF and FIPS. You'll see that I spell them out only at their first mention. I didn't bother for API, URL or REPL.

3) In general, "sub" words are not hyphenated or two words, so I don't think we should do PascalCase bicapitalization for field names like "SubCounty" or "SubParcel."

4) We've been stating it as UPI version 2.0, UPI Version 2.0, UPI 2.0 or UPI v2 in call notes, but not UPIv2.

5) I tend to remove most contractions from instructional documentation.

You'll see other style changes to tighten language, use commas for independent clauses and remove commas for dependent clauses. Boring stuff.

I don't see the "subcountry" concept in this documentation, not to be confused with "subcounty." I don't know offhand if that needs to be added here or later.